### PR TITLE
add setuptools_scm as build dependency

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 # This file was generated automatically from conda-smithy. To update this configuration,
 # update the conda-forge.yml and/or the recipe/meta.yaml.
-# -*- mode: yaml -*-
+# -*- mode: jinja-yaml -*-
 
 version: 2
 

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -33,9 +33,9 @@ CONDARC
 
 
 mamba install --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3
+    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
 mamba update --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3
+    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
   sha256: {{ hash }}
 
 build:
-  number: 1
+  number: 2
   script: {{ PYTHON }} -m pip install . --no-deps -vv
   noarch: python
 
@@ -22,6 +22,7 @@ requirements:
     - python >=3.8.0
     - pip
     - setuptools
+    - setuptools_scm
 
   run:
     - python >=3.8.0
@@ -35,6 +36,8 @@ requirements:
     # - geopandas >=0.3.0
 
 test:
+  requires:
+    - pip
   imports:
     - plotnine
     - plotnine.coords
@@ -47,6 +50,10 @@ test:
     - plotnine.scales
     - plotnine.stats
     - plotnine.themes
+  commands:
+    # The pip version can reported incorrectly if setuptools_scm isn't available
+    # at build time
+    - pip list | grep -i {{ name }} | grep {{ version }}
 
 about:
   home: https://github.com/has2k1/plotnine

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,6 +40,7 @@ test:
     - pip
     - pytest
     - pytest-cov
+    - geopandas
   imports:
     - plotnine
     - plotnine.coords

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -63,7 +63,7 @@ test:
     - pip check
     - echo $PWD
     - ls -larth
-    - pytest tests/
+    - pytest
 
 about:
   home: https://github.com/has2k1/plotnine

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -55,6 +55,7 @@ test:
     - plotnine.themes
   source_files:
     - "tests"
+    - "pyproject.toml"
   commands:
     # The pip version can reported incorrectly if setuptools_scm isn't available
     # at build time

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -63,7 +63,7 @@ test:
     - pip check
     - echo $PWD
     - ls -larth
-    - pytest
+    # - pytest
 
 about:
   home: https://github.com/has2k1/plotnine

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,6 +39,7 @@ test:
   requires:
     - pip
     - pytest
+    - pytest-cov
   imports:
     - plotnine
     - plotnine.coords
@@ -51,12 +52,16 @@ test:
     - plotnine.scales
     - plotnine.stats
     - plotnine.themes
+  source_files:
+    - "tests"
   commands:
     # The pip version can reported incorrectly if setuptools_scm isn't available
     # at build time
     - pip list | grep -i {{ name }} | grep {{ version }}
     - pip check
-    - pytest
+    - echo $PWD
+    - ls -larth
+    - pytest tests/
 
 about:
   home: https://github.com/has2k1/plotnine

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,6 +38,7 @@ requirements:
 test:
   requires:
     - pip
+    - pytest
   imports:
     - plotnine
     - plotnine.coords
@@ -54,6 +55,8 @@ test:
     # The pip version can reported incorrectly if setuptools_scm isn't available
     # at build time
     - pip list | grep -i {{ name }} | grep {{ version }}
+    - pip check
+    - pytest
 
 about:
   home: https://github.com/has2k1/plotnine


### PR DESCRIPTION
Try to fix #20 
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
