### PR TITLE
fix: mizani dep limit

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
   sha256: {{ hash }}
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . --no-deps -vv
   noarch: python
 
@@ -27,7 +27,7 @@ requirements:
   run:
     - python >=3.8.0
     - matplotlib-base >=3.6.0
-    - mizani >=0.9.0
+    - mizani >=0.9.0, <0.10.0
     - numpy >=1.23.0
     - pandas >=1.5.0
     - patsy >=0.5.1


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

This adds an upper limit on `mizani` consistent with the `pypi` release. Relevant [commit](https://github.com/has2k1/plotnine/commit/faed66fdc9a503946ef48f7cc374904c1da6d341)

<!--
Please add any other relevant info below:
-->
